### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,30 +6,30 @@
 # Datatypes (KEYWORD1)
 #######################################
  
-IAMFlexy				KEYWORD1
-PIDController			KEYWORD1
+IAMFlexy	KEYWORD1
+PIDController	KEYWORD1
  
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
  
-calibrate				KEYWORD2
-setFanSpeedPerc			KEYWORD2
-setFanSpeedNorm			KEYWORD2
-setFanSpeedRPM			KEYWORD2
-getBendPerc				KEYWORD2
-getBendNorm				KEYWORD2
-getUserInputPerc		KEYWORD2
-getUserInputNorm		KEYWORD2
-initFilter				KEYWORD2
-applyFilter				KEYWORD2
-setProportionalGain		KEYWORD2
-setIntegralGain			KEYWORD2
-setDerivativeGain		KEYWORD2
+calibrate	KEYWORD2
+setFanSpeedPerc	KEYWORD2
+setFanSpeedNorm	KEYWORD2
+setFanSpeedRPM	KEYWORD2
+getBendPerc	KEYWORD2
+getBendNorm	KEYWORD2
+getUserInputPerc	KEYWORD2
+getUserInputNorm	KEYWORD2
+initFilter	KEYWORD2
+applyFilter	KEYWORD2
+setProportionalGain	KEYWORD2
+setIntegralGain	KEYWORD2
+setDerivativeGain	KEYWORD2
 setInitialConditions	KEYWORD2
-saturation				KEYWORD2
-reset					KEYWORD2
-compute					KEYWORD2
+saturation	KEYWORD2
+reset	KEYWORD2
+compute	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords